### PR TITLE
design: 게시물 작성 사진 절대값으로 불러오게 수정

### DIFF
--- a/src/pages/PostUpload/PostUploadStyle.jsx
+++ b/src/pages/PostUpload/PostUploadStyle.jsx
@@ -48,8 +48,13 @@ const ImgDiv = styled.div`
   width: 30.3rem;
   height: 30.4rem;
   border-radius: 1rem;
-  object-fit: cover; 
   overflow:hidden;
+
+  img{
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
 `;
 
 const Label = styled.label`


### PR DESCRIPTION
## 개요
게시물 작성시 이미지 잘림 문제 수정했습니다

## 작업사항
ImgDiv안의 img에  width: 100%; height: 100%; object-fit: cover;  적용했습니다.